### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Einrichtung
 Bitte versichere dich, dass du die nötigen Schriften installiert hast:
 - [JetBrains Mono](https://www.jetbrains.com/de-de/lp/mono/)
-- Calibri
+- Calibri (Linux & MacOS-User können den Calibri-Klon [Carlito](https://fonts.google.com/specimen/Carlito) verwenden)
 
 Die Zusammenfassungen von den Semestern 1-3 wurden mit Word erstellt, die restlichen mit Typst.
 


### PR DESCRIPTION
### Add hint for Linux & MacOS users to use the Carlito font

I randomly stumbled upon Carlito, a free & libre font that aims to have the same size and spacing as Calibri, thus can be used as a drop-in replacement on non-Windows OS and the web. Can be useful for local Typst compiles and Word document edits without having to source the Calibri TTFs from a Windows install.

For more information, see https://de.wikipedia.org/wiki/Calibri#Freie_Alternative:_Carlito