### PR TITLE
Create GitHub Workflow to compile Typst files

### DIFF
--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -31,5 +31,5 @@ jobs:
         run: |
           find -regex '.*\(Zusammenfassung\|Spick\).*.typ' | while read file; do
             echo "Compiling $file"
-            typst compile --root "./" --diagnostic-format short "$file" "$(basename "${file%.typ}.pdf")
+            typst compile --root "./" --diagnostic-format short "$file" "$(basename "${file%.typ}.pdf")"
           done

--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+name: compile-typst
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/typst/typst:v0.13.1
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Compile Zusammenfassungen
+        run: |
+          find -regextype posix-extended -regex '.*(Zusammenfassung|Spick).*.typ' | while read file; do
+            echo "Compiling $file"
+            typst compile --root "./" "$file" "$(basename "${file%.typ}.pdf")"
+          done

--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -29,7 +29,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Compile Zusammenfassungen
         run: |
-          find -regextype posix-extended -regex '.*(Zusammenfassung|Spick).*.typ' | while read file; do
+          find -regex '.*\(Zusammenfassung\|Spick\).*.typ' | while read file; do
             echo "Compiling $file"
             typst compile --root "./" "$file" "$(basename "${file%.typ}.pdf")"
           done

--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -31,5 +31,5 @@ jobs:
         run: |
           find -regex '.*\(Zusammenfassung\|Spick\).*.typ' | while read file; do
             echo "Compiling $file"
-            typst compile --root "./" "$file" "$(basename "${file%.typ}.pdf")"
+            typst compile --root "./" --diagnostic-format short "$file" "$(basename "${file%.typ}.pdf")
           done


### PR DESCRIPTION
This is just for confirming that the Typst files still compile after changes. The resulting PDFs are not processed further