### PR TITLE
Update Typst template for HS25

### DIFF
--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/typst/typst:v0.13.1
+      image: ghcr.io/typst/typst:0.14.2
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CPl/CPl_Zusammenfassung_HS24_NG_JT.typ
+++ b/CPl/CPl_Zusammenfassung_HS24_NG_JT.typ
@@ -15,7 +15,6 @@
 // to use the CPPR Links in the CAMPLA exam environment
 
 // Document-specific settings
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #show grid: set par(justify: false, linebreaks: "optimized")
 
 #include "01_Introduction.typ"

--- a/CPlA/CPlA_Zusammenfassung_FS25_NG_JT_MG.typ
+++ b/CPlA/CPlA_Zusammenfassung_FS25_NG_JT_MG.typ
@@ -29,7 +29,6 @@
 }
 
 // Document-specific settings
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #show grid: set par(justify: false, linebreaks: "optimized")
 #show table.cell: set par(justify: false)
 

--- a/Dsy/DSy_Zusammenfassung_FS25_NG_JT.typ
+++ b/Dsy/DSy_Zusammenfassung_FS25_NG_JT.typ
@@ -11,7 +11,6 @@
 )
 
 // Document-specific settings
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #set table(columns: (1fr, 1fr))
 #show table: set par(justify: false, linebreaks: "optimized")
 

--- a/ExEv/ExEv_Zusammenfassung_HS24_NG_JT.typ
+++ b/ExEv/ExEv_Zusammenfassung_HS24_NG_JT.typ
@@ -15,7 +15,6 @@
 #let y- = $dash(y)$ // Mittelwert von y
 
 // Document specific settings
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #show table.cell: set par(justify: false)
 
 #let example-block(body) = {

--- a/MsTe/MsTe_Zusammenfassung_HS24_NG_JT.typ
+++ b/MsTe/MsTe_Zusammenfassung_HS24_NG_JT.typ
@@ -1621,6 +1621,7 @@ Ein Default Constructor hat keine Parameter. Er hat in Klassen und Structs ander
 
     Ein Operator kann "alles" machen, man sollte sie aber nur dann implementieren, wenn Resultat eines Operators
     für den Anwender "natürlich" wirkt.
+
     #quote(block: false)[When in doubt, do as the `int`s do]
   ],
   [

--- a/MsTe/MsTe_Zusammenfassung_HS24_NG_JT.typ
+++ b/MsTe/MsTe_Zusammenfassung_HS24_NG_JT.typ
@@ -12,7 +12,6 @@
 )
 
 // Global configuration
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #show grid: set par(justify: false, linebreaks: "optimized")
 #set figure(supplement: none)
 

--- a/VWL-TG/README.md
+++ b/VWL-TG/README.md
@@ -1,0 +1,6 @@
+Die VWL-Zusammenfassung ist wegen ihrer vielen Bilder zu gross für das Studentenportal. Mit dem folgenden GhostScript-Befehl
+kann das PDF auf eine angemessene Grösse komprimiert werden, ohne einen gross sichtbaren Qualitätsverlust der Bilder.
+
+```sh
+gs -sDEVICE=pdfwrite -dPDFSETTINGS=/printer -dNOPAUSE -dBATCH -sOutputFile=VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.pdf VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.pdf
+```

--- a/VWL-TG/README.md
+++ b/VWL-TG/README.md
@@ -1,5 +1,8 @@
-Die VWL-Zusammenfassung ist wegen ihrer vielen Bilder zu gross für das Studentenportal. Mit dem folgenden GhostScript-Befehl
-kann das PDF auf eine angemessene Grösse komprimiert werden, ohne einen gross sichtbaren Qualitätsverlust der Bilder.
+# Komprimierung der VWL-Zusammenfassung
+
+Das PDF der VWL-Zusammenfassung ist wegen seiner vielen Bilder zu gross für das Studentenportal. Mit dem folgenden GhostScript-Befehl
+kann das PDF auf eine angemessene Dateigrösse komprimiert werden, ohne dass die Bilder sichtbare Qualitätseinbussen erleiden.
+Damit passt es auch auf das Studentenportal. Das PDF in diesem Repository wurde _nicht_ komprimiert.
 
 ```sh
 gs -sDEVICE=pdfwrite -dPDFSETTINGS=/printer -dNOPAUSE -dBATCH -sOutputFile=VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.pdf VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.pdf

--- a/VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.typ
+++ b/VWL-TG/VwlWp_Zusammenfassung_FS25_JT_MG_MS.typ
@@ -11,7 +11,6 @@
 )
 
 // Document-specific settings
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 #show figure.caption: set text(hyphenate: false)
 
 = Wohlstand

--- a/WrStat/WrStat_Zusammenfassung_HS24_NG_JT.typ
+++ b/WrStat/WrStat_Zusammenfassung_HS24_NG_JT.typ
@@ -17,8 +17,6 @@
 )
 
 // Global configuration
-// Grid size defaults
-#set grid(columns: (1fr, 1fr), gutter: 1em)
 
 // Icon for the "Construct" button on the TI n-spire
 #let tr-constructs-button = box(

--- a/helpers.typ
+++ b/helpers.typ
@@ -1,5 +1,5 @@
 // Helper functions
-// (C) 2025 Nina Grässli, Jannis Tschan
+// (C) 2026 Nina Grässli, Jannis Tschan
 
 #let number-format(n, chunks, num-suffix) = {
   box(

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -1,5 +1,5 @@
 // Template Zusammenfassung
-// (C) 2025 Nina Grässli, Jannis Tschan
+// (C) 2026 Nina Grässli, Jannis Tschan
 #import "helpers.typ": *
 
 // Global variables
@@ -57,7 +57,7 @@
 
   let footer = context [
     #set text(font: font-special.font, size: 0.9em)
-    #let separator = if (authors.len() > 2) { ", " } else { " & " } 
+    #let separator = if (authors.len() > 2) { ", " } else { " & " }
     #fach | #semester | #authors.join(separator)
     #h(1fr)
     #languages.at(language).page #counter(page).display()

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -164,17 +164,17 @@
   }
 
   // Title page configuration
-  let subtitle(subt) = [
-    #set text(..font-special, size: 1.2em)
-    #pad(bottom: 1.3em, subt)
-  ]
+  let subtitle(subt) = {
+    set text(..font-special, size: 0.7em)
+    pad(bottom: 1.3em, subt)
+  }
 
   // == Page Content ==
-  // title row
+  // The title header
   if (display-title-footer) {
-    align(left)[
-      #text(..font-special, size: 1.8em, fach-long + " | " + fach)
-      #v(1em, weak: true)
+    title[
+      #text(..font-special, size: 1.06em, fach-long + " | " + fach)
+      #v(0.6em, weak: true)
       #subtitle[Zusammenfassung]
     ]
   }

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -121,6 +121,9 @@
   // Recommended workaround in Typst 0.11 until table.header is styleable
   show table.cell.where(y: 0): emph
 
+  // Set default sizing of grid
+  set grid(columns: (1fr, 1fr), gutter: 1em)
+
   // Unordered list, use with "- " or #list[]
   show list: set list(marker: "–", body-indent: 0.45em)
 

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -133,7 +133,6 @@
   // Quotes
   set quote(block: true, quotes: true)
   show quote: q => {
-    set align(left)
     set text(style: "italic")
     q
   }

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -195,7 +195,12 @@
   }
 
   // Main body
-  set par(justify: true)
+  set par(
+    justify: true,
+    // Use character-level justification with recommended values
+    // https://typst.app/docs/reference/model/par/#parameters-justification-limits
+    justification-limits: (tracking: (min: -0.01em, max: 0.02em)),
+  )
   body
 
   // Appendix Documents

--- a/template_zusammenf.typ
+++ b/template_zusammenf.typ
@@ -50,7 +50,7 @@
 
   let font-special = (
     ..font-default,
-    font: "JetBrains Mono",
+    font: ("JetBrains Mono", "DejaVu Sans Mono"),
     weight: "bold",
     fill: colors.hellblau,
   )


### PR DESCRIPTION
Adds our template changes for HS25. I'm currently working on updating the older Zusammenfassungen to Typst 0.14.2, as there is some layout breakage. But I decided to split these changes up into its own PR to keep it manageble :)

Additionally, this PR also adds
- Update Typst container in GitHub workflow
- Add README on how to compress the VWL PDF with GhostScript