### PR TITLE
ci: Update Typst to 0.15.1

### DIFF
--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/typst/typst:0.15.0
+      image: ghcr.io/typst/typst:0.15.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/compile-typst.yml
+++ b/.github/workflows/compile-typst.yml
@@ -19,12 +19,12 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/typst/typst:0.14.2
+      image: ghcr.io/typst/typst:0.15.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Runs a single command using the runners shell
       - name: Compile Zusammenfassungen


### PR DESCRIPTION
Also updates the "checkout" action, which is needed to actually access the content of the Git repository in the pipeline (GitHub doing GitHub things, why are there six different versions of an action this simple???)